### PR TITLE
Properly handle image searches by URL or photo ID

### DIFF
--- a/src/unsplash.js
+++ b/src/unsplash.js
@@ -95,6 +95,11 @@ export function getImagesURLsForItems (items, { searchTerm, photoId }) {
           if (json.errors) {
             return Promise.reject(json.errors[0])
           }
+          if (!Array.isArray(json)) {
+            // must have been a photoId search,
+            // fill an array we can iterate over
+            json = new Array(count).fill(json)
+          }
           return json.map((data, j) => ({
             data,
             ...itemsForOrientation[30 * i + j]

--- a/src/unsplash.js
+++ b/src/unsplash.js
@@ -69,7 +69,23 @@ export function getImagesURLsForItems (items, { searchTerm, photoId }) {
 
   let action = photoId ? `/photos/${photoId}` : '/photos/random'
   let url = API_ENDPOINT + action + '?client_id=' + API_KEY
-  if (!photoId) {
+
+  if (photoId) {
+    return fetch(url, apiOptions)
+      .then(response => response.json())
+      .then(json => {
+        if (json.errors) {
+          return Promise.reject(json.errors[0])
+        }
+        json = new Array(items.length).fill(json)
+        return json.map((data, j) => ({
+          data,
+          ...flatten(Object.values(orientations))[j]
+        }))
+      }).catch(error => {
+        return [{ error }]
+      })
+  } else if (!photoId) {
     if (searchTerm) {
       url += '&query=' + searchTerm
     }
@@ -94,11 +110,6 @@ export function getImagesURLsForItems (items, { searchTerm, photoId }) {
         .then(json => {
           if (json.errors) {
             return Promise.reject(json.errors[0])
-          }
-          if (!Array.isArray(json)) {
-            // must have been a photoId search,
-            // fill an array we can iterate over
-            json = new Array(count).fill(json)
           }
           return json.map((data, j) => ({
             data,

--- a/src/unsplash.js
+++ b/src/unsplash.js
@@ -85,11 +85,12 @@ export function getImagesURLsForItems (items, { searchTerm, photoId }) {
       }).catch(error => {
         return [{ error }]
       })
-  } else if (!photoId) {
-    if (searchTerm) {
-      url += '&query=' + searchTerm
-    }
   }
+  
+  if (searchTerm) {
+    url += '&query=' + searchTerm
+  }
+
 
   return Promise.all(Object.keys(orientations).map(orientation => {
     const itemsForOrientation = orientations[orientation]


### PR DESCRIPTION
Fixes #19
Since https://github.com/BohemianCoding/unsplash-sketchplugin/commit/2d89f034f47d73c9759d4f3831f329da45f78728, searching for a photo by URL or photo ID would fail. By converting the JSON response to an array, the existing code can now properly handle ID searches.